### PR TITLE
Add missing PCH file for sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 
 # Precompiled Headers
 *.gch
-*.pch
 
 # Compiled Dynamic libraries
 *.so

--- a/samples/basic/xcode/basic_Prefix.pch
+++ b/samples/basic/xcode/basic_Prefix.pch
@@ -1,0 +1,13 @@
+
+#if defined( __cplusplus )
+    #include "cinder/Cinder.h"
+
+    #include "cinder/app/App.h"
+
+    #include "cinder/gl/gl.h"
+
+    #include "cinder/CinderMath.h"
+    #include "cinder/Matrix.h"
+    #include "cinder/Vector.h"
+    #include "cinder/Quaternion.h"
+#endif


### PR DESCRIPTION
Tiny fix to get the sample building - A precompiled header isn't required by Xcode (in fact, modern Xcode no longer creates them for new projects), but in this case the project references it and without it, additional includes would be needed in the source files.